### PR TITLE
image-specs: install dhcp client

### DIFF
--- a/image-specs/stage0/00-configure/01-packages
+++ b/image-specs/stage0/00-configure/01-packages
@@ -43,6 +43,8 @@ htop
 iperf
 iperf3
 iputils-ping
+isc-dhcp-client
+isc-dhcp-common
 keyboard-configuration
 less
 libboost-dev

--- a/image-specs/stage0/02-enable-access-point/00-run.sh
+++ b/image-specs/stage0/02-enable-access-point/00-run.sh
@@ -12,6 +12,9 @@ install -m 644 files/br0-member-wlan0.network "${ROOTFS_DIR}/etc/systemd/network
 install -m 755 files/p4pi-setup "${ROOTFS_DIR}/usr/sbin/"
 install -m 644 files/p4pi-setup.service "${ROOTFS_DIR}/lib/systemd/system/"
 
+# Switch off binding to port 53 to avoid conflict with dnsmasq
+install -m 644 files/resolved.conf "${ROOTFS_DIR}/etc/systemd/"
+
 on_chroot << EOF
 
 # Enable IPv4 routing
@@ -21,8 +24,11 @@ echo 'net.ipv4.ip_forward=1' >> /etc/sysctl.d/routed-ap.conf
 systemctl unmask hostapd
 systemctl enable hostapd
 
+# Setup DNS if available
+systemctl enable systemd-resolved.service
+
 # Create and setup interfaces on startup
-systemctl enable systemd-networkd
+systemctl enable systemd-networkd.service
 systemctl enable p4pi-setup.service
 
 sed -i 's|#DAEMON_CONF.*$|DAEMON_CONF="/etc/hostapd/hostapd.conf"|' /etc/default/hostapd

--- a/image-specs/stage0/02-enable-access-point/files/dnsmasq.conf
+++ b/image-specs/stage0/02-enable-access-point/files/dnsmasq.conf
@@ -681,5 +681,6 @@
 # P4Pi access point config
 interface=wlan0
 dhcp-range=192.168.0.2,192.168.0.20,255.255.255.0,24h
-domain=wlan
-address=/gw.wlan/192.168.0.1
+domain=p4pi
+address=/gw.p4pi/192.168.0.1
+server=1.1.1.1

--- a/image-specs/stage0/02-enable-access-point/files/resolved.conf
+++ b/image-specs/stage0/02-enable-access-point/files/resolved.conf
@@ -1,0 +1,30 @@
+#  This file is part of systemd.
+#
+#  systemd is free software; you can redistribute it and/or modify it
+#  under the terms of the GNU Lesser General Public License as published by
+#  the Free Software Foundation; either version 2.1 of the License, or
+#  (at your option) any later version.
+#
+# Entries in this file show the compile time defaults.
+# You can change settings by editing this file.
+# Defaults can be restored by simply deleting this file.
+#
+# See resolved.conf(5) for details
+
+[Resolve]
+# Some examples of DNS servers which may be used for DNS= and FallbackDNS=:
+# Cloudflare: 1.1.1.1 1.0.0.1 2606:4700:4700::1111 2606:4700:4700::1001
+# Google:     8.8.8.8 8.8.4.4 2001:4860:4860::8888 2001:4860:4860::8844
+# Quad9:      9.9.9.9 2620:fe::fe
+#DNS=
+#FallbackDNS=
+#Domains=
+#DNSSEC=no
+#DNSOverTLS=no
+#MulticastDNS=yes
+#LLMNR=yes
+#Cache=yes
+DNSStubListener=no
+#DNSStubListenerExtra=
+#ReadEtcHosts=yes
+#ResolveUnicastSingleLabel=no

--- a/p4pi-web/debian/changelog
+++ b/p4pi-web/debian/changelog
@@ -1,5 +1,5 @@
-p4pi-web (0.1.0-2) bullseye; urgency=medium
+p4pi-web (0.1.0-3) bullseye; urgency=medium
 
   * Initial release
 
- -- Radostin Stoyanov <radostin@stoyanov.io>  Thu, 05 Aug 2021 18:26:40 +0100
+ -- Radostin Stoyanov <radostin@stoyanov.io>  Sun, 15 Aug 2021 12:12:29 +0100


### PR DESCRIPTION
This PR installs the `isc-dhcp-client` and `isc-dhcp-common` packages and enables `systemd-resolved` service on startup.