### PR TITLE
Set vagrant box name

### DIFF
--- a/vm/Vagrantfile
+++ b/vm/Vagrantfile
@@ -3,6 +3,7 @@
 
 Vagrant.configure("2") do |config|
   config.vm.box = "debian/bullseye64"
+  config.vm.define "p4pi"
 
   config.vm.network "public_network"
 


### PR DESCRIPTION
This PR sets the Vagrant box name to 'p4pi' instead of the good old 'default'. The box name is used in vagrant commands such as:
```sh
$ vagrant status
Current machine states:

p4pi                      running (virtualbox)
...
```
or 
```sh
$ vagrant global-status
id       name   provider   state    directory                           
------------------------------------------------------------------------   
a5a652b  p4pi   virtualbox running  /home/levait/p4pi/vm                
 ...
```