### PR TITLE
fix(image-spec): change veth mac address to compatible ones

### DIFF
--- a/image-specs/stage0/02-enable-access-point/files/p4pi-setup
+++ b/image-specs/stage0/02-enable-access-point/files/p4pi-setup
@@ -11,10 +11,10 @@ brctl setageing br0 0
 ip link add dev veth0 type veth peer name veth0-1
 ip link add dev veth1 type veth peer name veth1-1
 
-ip link set dev veth0 address 00:04:00:00:00:00
-ip link set dev veth0-1 address 00:04:00:00:00:10
-ip link set dev veth1 address 00:04:00:00:10:00
-ip link set dev veth1-1 address 00:04:00:00:10:10
+ip link set dev veth0 address 10:04:00:00:00:00
+ip link set dev veth0-1 address 10:04:00:00:00:10
+ip link set dev veth1 address 10:04:00:00:10:00
+ip link set dev veth1-1 address 10:04:00:00:10:10
 
 ip link set dev veth0 up
 ip link set dev veth1 up


### PR DESCRIPTION
Fix #38 
With the previous addresses the table entry that was inserted(for the l2switch example ping drop test) has truncated the starting 00