### PR TITLE
examples: update links of images

### DIFF
--- a/examples/t4p4s/calc/README.md
+++ b/examples/t4p4s/calc/README.md
@@ -3,7 +3,7 @@
 In this example, we use the default settings of P4Pi as depicted in the following figure:
 
 <p align="center">
-  <img alt="Default settings of P4Pi" width="600px" src="../../images/l2switch_setupA.png">
+  <img alt="Default settings of P4Pi" width="600px" src="../../../docs/images/l2switch_setupA.png">
 </p>
 
 This example is based on the P4 tutorial exercise called [calc](https://github.com/p4lang/tutorials/tree/master/exercises/calc).

--- a/examples/t4p4s/l2switch/README.md
+++ b/examples/t4p4s/l2switch/README.md
@@ -11,7 +11,7 @@ P4 source code: [l2switch.p4](l2switch.p4).
 The following figure depicts the setup used in this example:
 
 <p align="center">
-  <img alt="Default settings of P4Pi" width="600px" src="../../images/l2switch_setupA.png">
+  <img alt="Default settings of P4Pi" width="600px" src="../../../docs/images/l2switch_setupA.png">
 </p>
 
 P4Pi runs a DHCP daemon (dnsmasq) to assign IP addresses to devices connected through WiFi. The generated T4P4S switch interconnects the wireless interface wlan0 and the linux bridge br1. However, the 1GE Ethernet port eth0 is not used in this example. The default management IP address is assigned to br0. Through this IP address the P4Pi node is accessible (e.g., via the web interface or SSH).
@@ -76,7 +76,7 @@ sudo tcpdump -i br0 icmp
 The following figure depicts another setup where P4Pi node acts as a low level relay or proxy between your laptop and your home router (or a private network) connected to the 1GE wired Ethernet port.
 
 <p align="center">
-  <img alt="Low level gateway mode of P4Pi" width="900px" src="../../images/l2switch_setupB.png">
+  <img alt="Low level gateway mode of P4Pi" width="900px" src="../../../docs/images/l2switch_setupB.png">
 </p>
 
 ### Step 1 - Connect to P4Pi

--- a/examples/t4p4s/stateful-firewall/README.md
+++ b/examples/t4p4s/stateful-firewall/README.md
@@ -18,7 +18,7 @@ If the packet comes from the external network, we compute the same hash `index=h
 The following figure illustrates the setup of a P4Pi node:
 
 <p align="center">
-  <img alt="Default settings of P4Pi" width="600px" src="../../images/l2switch_setupA.png">
+  <img alt="Default settings of P4Pi" width="600px" src="../../../docs/images/l2switch_setupA.png">
 </p>
 
 For more detailed information check the [Simple L2 Switch example](../l2switch/README.md)
@@ -117,7 +117,7 @@ sudo ip netns exec gigport iperf -c xyz -t 60 -i 1 # Where xyz is your IP addres
 The following figure depicts another setup where P4Pi node acts as a low level relay or proxy between your laptop and your home router (or a private network) connected to the 1GE wired Ethernet port.
 
 <p align="center">
-  <img alt="Low level gateway mode of P4Pi" width="900px" src="../../images/l2switch_setupB.png">
+  <img alt="Low level gateway mode of P4Pi" width="900px" src="../../../docs/images/l2switch_setupB.png">
 </p>
 
 ### Step 1 - Connect to P4Pi

--- a/examples/t4p4s/traffic-filter/README.md
+++ b/examples/t4p4s/traffic-filter/README.md
@@ -26,7 +26,7 @@ We use blocklisting, which involves defining which entities should be blocked. S
 The following figure depicts the default setup of a P4Pi node:
 
 <p align="center">
-  <img alt="Default settings of P4Pi" width="600px" src="../../images/l2switch_setupA.png">
+  <img alt="Default settings of P4Pi" width="600px" src="../../../docs/images/l2switch_setupA.png">
 </p>
 
 For more detailed information check the [Simple L2 Switch example](../l2switch/README.md#testing-with-wifi-access-only)
@@ -122,7 +122,7 @@ te.insert
 The following figure depicts another setup where P4Pi node acts as a low level relay or proxy between your laptop and your home router (or a private network) connected to the 1GE wired Ethernet port.
 
 <p align="center">
-  <img alt="Low level gateway mode of P4Pi" width="900px" src="../../images/l2switch_setupB.png">
+  <img alt="Low level gateway mode of P4Pi" width="900px" src="../../../docs/images/l2switch_setupB.png">
 </p>
 
 ### Step 1 - Connect to P4Pi


### PR DESCRIPTION
In commit 65a49d5 the examples directory was moved to the root of the git repository to enable the P4 code of the examples to be installed as debian package in P4Pi. This patch updates all relative links of the README for each example.